### PR TITLE
Repaint ArchHierarchyWindow on playModeStateChanged

### DIFF
--- a/src/Arch.Unity/Assets/Arch.Unity/Editor/ArchHierarchyWindow.cs
+++ b/src/Arch.Unity/Assets/Arch.Unity/Editor/ArchHierarchyWindow.cs
@@ -39,6 +39,7 @@ namespace Arch.Unity.Editor
         void OnPlayModeStateChanged(PlayModeStateChange playModeStateChange)
         {
             treeView.SetSelection(Array.Empty<int>());
+            Repaint();
         }
 
         void OnGUI()


### PR DESCRIPTION
When "Reload Scene" of EnterPlayModeOption is disabled, there is a problem that Arch Hierarchy is not updated during play.
To avoid this, repaint in OnPlayModeStateChanged.