### PR TITLE
Fix: pointers are not assumed as unmanaged type

### DIFF
--- a/src/Arch.Unity/Assets/Arch.Unity/Runtime/Internal/TypeExtensions.cs
+++ b/src/Arch.Unity/Assets/Arch.Unity/Runtime/Internal/TypeExtensions.cs
@@ -11,22 +11,27 @@ namespace Arch.Unity
 
         public static bool IsUnmanaged(this Type type)
         {
-            if (!_isUnmanagedCache.TryGetValue(type, out bool result))
+            if (_isUnmanagedCache.TryGetValue(type, out bool result))
             {
-                if (type.IsValueType || type.IsEnum || type.IsPointer)
-                {
-                    result = true;
-                }
-                else
-                {
-                    result = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-                        .All(f => IsUnmanaged(f.FieldType));
-                }
-
-                _isUnmanagedCache[type] = result;
+                return result;
             }
+            
+			if (type.IsPrimitive || type.IsEnum || type.IsPointer)
+			{
+				result = true;
+			}
+			else if (type.IsValueType)
+			{
+				result = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+							 .All(field => field.FieldType.IsUnmanaged());
+			}
+			else
+			{
+				result = false;
+			}
 
-            return result;
+			_isUnmanagedCache[type] = result;
+			return result;
         }
     }
 }

--- a/src/Arch.Unity/Assets/Arch.Unity/Runtime/Internal/TypeExtensions.cs
+++ b/src/Arch.Unity/Assets/Arch.Unity/Runtime/Internal/TypeExtensions.cs
@@ -13,11 +13,7 @@ namespace Arch.Unity
         {
             if (!_isUnmanagedCache.TryGetValue(type, out bool result))
             {
-                if (!type.IsValueType)
-                {
-                    result = false;
-                }
-                else if (type.IsPrimitive || type.IsPointer || type.IsEnum)
+                if (type.IsValueType || type.IsEnum || type.IsPointer)
                 {
                     result = true;
                 }


### PR DESCRIPTION
This pull request fixes an issue where pointer types were not correctly recognized as unmanaged in the IsUnmanaged method of TypeExtensions.

- Pointer types are now properly identified as unmanaged.

This fix allows Unity's NativeCollection types, like NativeArray and NativeList, which may contain pointers, to be used in Unity's Job System without issues.

Related Issue:
[Pointer types not correctly identified as unmanaged in IsUnmanaged method](https://github.com/AnnulusGames/Arch.Unity/issues/33)

