### PR TITLE
Fix: pointers are not recognized as unmanaged type

### DIFF
--- a/src/Arch.Unity/Assets/Arch.Unity/Runtime/Internal/TypeExtensions.cs
+++ b/src/Arch.Unity/Assets/Arch.Unity/Runtime/Internal/TypeExtensions.cs
@@ -13,14 +13,14 @@ namespace Arch.Unity
         {
             if (!_isUnmanagedCache.TryGetValue(type, out bool result))
             {
-                if (!type.IsValueType)
-                {
-                    result = false;
-                }
-                else if (type.IsPrimitive || type.IsPointer || type.IsEnum)
+                if (type.IsPrimitive || type.IsPointer || type.IsEnum)
                 {
                     result = true;
                 }
+                else if (!type.IsValueType)
+                {
+                    result = false;
+                }   
                 else
                 {
                     result = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)


### PR DESCRIPTION
This pull request fixes an issue where pointer types were not correctly recognized as unmanaged in the IsUnmanaged method of TypeExtensions.

- Pointer types are now properly identified as unmanaged.

This fix allows Unity's NativeCollection types, like NativeArray and NativeList, which may contain pointers, to be used in Unity's Job System without issues.

Related Issue:
[Pointer types not correctly identified as unmanaged in IsUnmanaged method](https://github.com/AnnulusGames/Arch.Unity/issues/33)

