### PR TITLE
Fix: Track and correctly destroy created component editors.

### DIFF
--- a/src/Arch.Unity/Assets/Arch.Unity/Editor/EntityEditor.cs
+++ b/src/Arch.Unity/Assets/Arch.Unity/Editor/EntityEditor.cs
@@ -22,6 +22,10 @@ namespace Arch.Unity.Editor
         void OnDisable()
         {
             EditorApplication.update -= Repaint;
+            foreach (var (_, editor) in editorCache)
+            {
+                DestroyImmediate(editor);
+            }
             editorCache.Clear();
         }
 
@@ -57,7 +61,11 @@ namespace Arch.Unity.Editor
                     {
                         if (component is UnityEngine.Component c)
                         {
-                            if (!editorCache.TryGetValue(c, out var editor)) editor = CreateEditor(c);
+                            if (!editorCache.TryGetValue(c, out var editor))
+                            {
+                                editor = CreateEditor(c);
+                                editorCache.Add(c, editor);
+                            }
                             if (editor != null) editor.OnInspectorGUI();
                         }
                         else


### PR DESCRIPTION
# Issue
Currently, when I use Arch Hierarchy to inspect my hybrid entities, on consecutive game runs my console is full of editor errors.
<img width="2308" height="1326" alt="console_logs" src="https://github.com/user-attachments/assets/b20e37b4-78dc-4dc5-a912-b27e1e8942e1" />

This happens because when we create Editors for `MonoBehaviour` components, we never track them and never destroy their instances in `OnDisable`.

# Fix
- Track all  created `Editor` instances.
- Properly destroy them in `OnDisable`.
